### PR TITLE
README: small update in regard of visual bell

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ fg-color = "#c7eeff"
 bg-color = "#000000ee"
 unfocused-tint = "#00000033"
 
-no-flash = true
+visual-bell = none
 
 term = "xterm-256color"
 


### PR DESCRIPTION
The option changed with 7b6365a7ca23ddcfb61b0d9ab03b1630d842e899

_________________________
Just a small change as I noticed that wayst threw a warning for me that no-flash doesn't exist.
Didn't check if the rest of the README still holds up.