### PR TITLE
Treat Ctrl + @ as NULL

### DIFF
--- a/src/vt_core.c
+++ b/src/vt_core.c
@@ -4855,8 +4855,8 @@ static inline void Vt_scroll_out_all_content(Vt* self)
     }
 
     int64_t to_add = 0;
-    for (size_t i = Vt_visual_bottom_line(self); i >= Vt_visual_top_line(self); --i) {
-        if (self->lines.buf[i].data.size) {
+    for (size_t i = 0; i <= Vt_visual_bottom_line(self) - Vt_visual_top_line(self); ++i) {
+        if (self->lines.buf[Vt_visual_bottom_line(self) - i].data.size) {
             to_add += i;
             break;
         }

--- a/src/wl.c
+++ b/src/wl.c
@@ -969,9 +969,10 @@ static void keyboard_handle_key(void*               data,
         utf);
 
     // xkb will signal a failed conversion to utf32 by returning 0, but 0 is the expected result for
-    // Ctrl + `
+    // Ctrl + ` and Ctrl + @
     bool utf_conversion_success =
-      utf || (sym == XKB_KEY_grave && FLAG_IS_SET(mods, globalWl->xkb.ctrl_mask));
+      utf || ((sym == XKB_KEY_grave || sym == XKB_KEY_at ) &&
+        FLAG_IS_SET(mods, globalWl->xkb.ctrl_mask));
 
     bool is_not_consumed = utf_conversion_success ? true : !keysym_is_consumed(sym);
 


### PR DESCRIPTION
Adds Ctrl + @ to the check for legitimate key combinations when
xkb_{keysym_to,state_key_get}_utf32 returns 0.  This check already
existed to see if the key combination was Ctrl + `, but Ctrl + @ is
another way of typing NULL and wasn't being tested.