### PR TITLE
Don't default to gcc on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ BLD_DIR = build
 TGT_DIR = .
 
 ifeq ($(shell uname -s),FreeBSD)
-	CC?= gcc
 	INCLUDES = -I/usr/local/include/freetype2/
 	INCLUDES += -I/usr/local/include
 	LDLIBS = -lGL -lfreetype -lfontconfig -lutil -L/usr/local/lib -lm


### PR DESCRIPTION
Very minor nit. I often find myself editing the Makefile on a fresh clone to remove this line. FreeBSD ship with clang by default and compiles just fine with it. Also, GCC isn't called `gcc` on FreeBSD, but rather `gccX` where `X` is the version number e.g., `gcc13`.

P.S. Thanks for the awesome terminal emulator :)