### PR TITLE
Respect XCURSOR_THEME environment variable

### DIFF
--- a/src/wl.c
+++ b/src/wl.c
@@ -2443,7 +2443,9 @@ static void setup_cursor(struct WindowBase* self)
         size = WL_DEFAULT_CURSOR_SIZE;
     }
 
-    if (!(globalWl->cursor_theme = wl_cursor_theme_load(NULL, size, globalWl->shm))) {
+    if (!(globalWl->cursor_theme = wl_cursor_theme_load(getenv("XCURSOR_THEME"),
+                                                        size,
+                                                        globalWl->shm))) {
         WRN("Failed to load cursor theme\n");
         return;
     }


### PR DESCRIPTION
Trivially check for XCURSOR_THEME and pass it, if it exists, to wl_cursor_theme_load(...). getenv(char*) returns NULL should the environment variable not exist, which nicely results in the default behavior.

This does not revert to default cursors if the theme specified by XCURSOR_THEME can't be loaded for whatever reason. My assumption is a user won't set XCURSOR_THEME unless they know it's available.

Feel free to request any changes. I formatted this to avoid an especially long line.