### PR TITLE
Fix SGR 55 "not overlined" to terminate overline mode

### DIFF
--- a/src/vt_core.c
+++ b/src/vt_core.c
@@ -3751,6 +3751,11 @@ __attribute__((hot)) static void Vt_handle_single_argument_SGR(Vt*     self,
             r->strikethrough = false;
             break;
 
+        /* Not overlined (widely supported extension) */
+        case 55:
+            r->overline = false;
+            break;
+
         /* Set foreground color to default, ECMA-48 3rd */
         case 39:
             Vt_set_fg_color_default(self, opt_target);


### PR DESCRIPTION
SGR 53 enables overline (already supported), but the corresponding reset code 55 was not handled, causing "Unknown SGR code: 55" warnings instead of turning off the attribute.

Added the missing case in Vt_handle_single_argument_SGR(), modelled after similar attributes like strikethrough (9/29).