### PR TITLE
docs: fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To target OpenGL ES 2.0 instead of OpenGL 2.1 set ```renderer=gles20```.
 
 To build without libutf8proc set ```libutf8proc=off```.
 
-To build with debuging symbols set ```mode=debug``` or ```mode=debugoptimized```.
+To build with debugging symbols set ```mode=debug``` or ```mode=debugoptimized```.
 
 
 ## Installation from AUR

--- a/config.example
+++ b/config.example
@@ -3,7 +3,7 @@
 #
 #  This file format uses ini-like key-value syntax.
 #
-#  All options are equivalent to coresponding command line options (except for lower precedence).
+#  All options are equivalent to corresponding command line options (except for lower precedence).
 #  To get a list of all options run `wayst --help`.
 
 
@@ -379,12 +379,12 @@
 ## Close terminal
 #bind-key-quit=C+S+q
 
-## Print debuging information to stderr
+## Print debugging information to stderr
 #bind-key-debug=C+S+slash
 
 
 
-#=======================================[ DEBUGING OPTIONS ]========================================
+#=======================================[ DEBUGGING OPTIONS ]=======================================
 
 ## Output pty communication to stderr
 #debug-pty = true


### PR DESCRIPTION
Hi, this is my first contribution to wayst.

This PR fixes a few small documentation typos in the README and example config.
No behavior changes.

Tested:
- make